### PR TITLE
Fixed multiple calling of dummy listener

### DIFF
--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -104,7 +104,7 @@ function _dispatchEvent(event) {
 
 	dummyListener = this['on' + type];
 	if (typeof dummyListener === 'function') {
-		listenersType.push(dummyListener);
+		dummyListener.call(this, event);
 	}
 
 	for (i = 0; !!(listener = listenersType[i]); i++) {


### PR DESCRIPTION
Fixed this bug:

```
var yaeti = require('yaeti');


// Custom class we want to make an EventTarget.
function Foo() {
    // Make Foo an EventTarget.
    yaeti.EventTarget.call(this);
}

// Create an instance.
var foo = new Foo();

function listener1() {
    console.log('listener1');
}

function listener2() {
    console.log('listener2');
}

foo.onbar = function() {
    console.log('onbar');
}

foo.addEventListener('bar', listener1);
foo.addEventListener('bar', listener2);
foo.removeEventListener('bar', listener1);

var event = new yaeti.Event('bar');

foo.dispatchEvent(event);
foo.dispatchEvent(event);
```

Would print:

```
listener2
onbar
listener2
onbar
onbar
```

The problem is that `listenersType` would be pushing the dummy listener every time dispatch event gets called.
