### PR TITLE
Fix npm yaetipocalypse caused by gulpjs/gulp#v4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/ibc/yaeti.git"
   },
   "devDependencies": {
-    "gulp": "git+https://github.com/gulpjs/gulp.git#4.0",
+    "gulp": "^4.0.0",
     "gulp-jscs": "^4.0.0",
     "gulp-jscs-stylish": "^1.4.0",
     "gulp-jshint": "^2.0.4",


### PR DESCRIPTION
Gulp has removed the 4.0 branch from their GitHub repository, so the previous way of installing using `npm install gulpjs/gulp.git#4.0` no longer works.
https://stackoverflow.com/questions/33429727/how-do-i-install-gulp-4/
https://github.com/madoublet/respond/issues/598
https://github.com/theturtle32/WebSocket-Node/commit/3cb29e1041ecca0a9c21f809890204271900f6f6